### PR TITLE
Build directory creation added in to Makefile

### DIFF
--- a/makescl/Makefile
+++ b/makescl/Makefile
@@ -3,6 +3,7 @@ b = build/
 all: $(b)maketrd
 
 $(b)maketrd: maketrd.cpp trdfile.h trdfile.cpp sclfile.h sclfile.cpp fstools.cpp fstools.h
+	@mkdir -p $(b)
 	g++ -g trdfile.cpp maketrd.cpp sclfile.cpp fstools.cpp -o$@
 
 clean:


### PR DESCRIPTION
Добавил создание директории build/ в Makefile, без этого текущий master выдает ошибку:
```
...:~/Sandbox/zx_spectrum_game/makescl$ make
g++ -g trdfile.cpp maketrd.cpp sclfile.cpp fstools.cpp -obuild/maketrd
/usr/bin/ld: cannot open output file build/maketrd: No such file or directory
collect2: error: ld returned 1 exit status
Makefile:6: recipe for target 'build/maketrd' failed
make: *** [build/maketrd] Error 1
```